### PR TITLE
feat(waitForAvailable): test ports for server availability

### DIFF
--- a/lib/mongos.js
+++ b/lib/mongos.js
@@ -9,7 +9,8 @@ const Promise = require('bluebird'),
   EventEmitter = require('events').EventEmitter,
   CoreServer = require('mongodb-core').Server,
   spawn = require('child_process').spawn,
-  clone = require('./utils').clone;
+  clone = require('./utils').clone,
+  waitForAvailable = require('./utils').waitForAvailable;
 
 class Mongos extends EventEmitter {
   constructor(binary, options, clientOptions) {
@@ -258,22 +259,26 @@ class Mongos extends EventEmitter {
           // Only emit event at start
           if (self.state === 'stopped') {
             if (stdout.indexOf('waiting for connections') !== -1) {
-              if (self.logger.isInfo()) {
-                self.logger.info(f('successfully started mongos proxy [%s]', commandLine));
-              }
+              waitForAvailable(self.options.bind_ip, self.options.port, err => {
+                if (err) return reject(err);
 
-              // Emit running state
-              self.emit('state', {
-                event: 'running',
-                topology: 'mongos',
-                cmd: commandLine,
-                options: self.options
+                if (self.logger.isInfo()) {
+                  self.logger.info(f('successfully started mongos proxy [%s]', commandLine));
+                }
+
+                // Emit running state
+                self.emit('state', {
+                  event: 'running',
+                  topology: 'mongos',
+                  cmd: commandLine,
+                  options: self.options
+                });
+
+                // Mark state as running
+                self.state = 'running';
+                // Resolve
+                resolve();
               });
-
-              // Mark state as running
-              self.state = 'running';
-              // Resolve
-              resolve();
             }
           }
         });

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,7 +9,8 @@ const Promise = require('bluebird'),
   EventEmitter = require('events').EventEmitter,
   CoreServer = require('mongodb-core').Server,
   spawn = require('child_process').spawn,
-  clone = require('./utils').clone;
+  clone = require('./utils').clone,
+  waitForAvailable = require('./utils').waitForAvailable;
 
 class Server extends EventEmitter {
   constructor(binary, options, clientOptions) {
@@ -358,19 +359,23 @@ class Server extends EventEmitter {
               stdout.indexOf('waiting for connections') !== -1 ||
               stdout.indexOf('connection accepted') !== -1
             ) {
-              // Mark state as running
-              self.state = 'running';
+              waitForAvailable(self.options.bind_ip, self.options.port, err => {
+                if (err) return reject(err);
 
-              // Emit start event
-              self.emit('state', {
-                event: 'running',
-                topology: 'server',
-                cmd: commandLine,
-                options: self.options
+                // Mark state as running
+                self.state = 'running';
+
+                // Emit start event
+                self.emit('state', {
+                  event: 'running',
+                  topology: 'server',
+                  cmd: commandLine,
+                  options: self.options
+                });
+
+                // Resolve
+                resolve();
               });
-
-              // Resolve
-              resolve();
             }
           }
         });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 'use strict';
+const net = require('net');
 
 const clone = function(o) {
   var obj = {};
@@ -10,7 +11,81 @@ const delay = function(ms) {
   return new Promise(resolve => setTimeout(() => resolve(), ms));
 };
 
+/**
+ * Checks if a provided address is actively listening for incoming connections
+ *
+ * @param {string} host the host to connect to
+ * @param {number} port the port to check for availability
+ * @param {function} callback
+ */
+const checkAvailable = (host, port, callback) => {
+  const socket = new net.Socket();
+  function cleanup() {
+    socket.removeAllListeners('connect');
+    socket.removeAllListeners('error');
+    socket.end();
+    socket.destroy();
+    socket.unref();
+  }
+
+  socket.on('connect', () => {
+    cleanup();
+    callback(null, true);
+  });
+
+  socket.on('error', err => {
+    cleanup();
+    if (err.code !== 'ECONNREFUSED') {
+      return callback(err);
+    }
+
+    callback(null, false);
+  });
+
+  socket.connect({ port: port, host: host });
+};
+
+/**
+ * Waits for a provided address to actively listen for incoming connections on a given
+ * port.
+ *
+ * @param {string} host the host to connect to
+ * @param {number} port the port to check for availability
+ * @param {object} [options] optional settings
+ * @param {number} [options.retryMs] the amount of time to wait between retry attempts in ms
+ * @param {number} [options.retryCount] the number of times to attempt retry
+ * @param {function} callback
+ */
+const waitForAvailable = (host, port, options, callback) => {
+  if (typeof options === 'function') (callback = options), (options = {});
+  options = Object.assign(
+    {},
+    {
+      retryMs: 100,
+      retryCount: 10
+    },
+    options
+  );
+
+  let count = options.retryCount;
+
+  function run() {
+    checkAvailable(host, port, (err, available) => {
+      if (err) return callback(err);
+
+      count--;
+      if (available) return callback();
+      if (count === 0) return callback(new Error('Server is unavailable'));
+      setTimeout(() => run(), options.retryMs);
+    });
+  }
+
+  run();
+};
+
 module.exports = {
   clone: clone,
-  delay: delay
+  delay: delay,
+  checkAvailable: checkAvailable,
+  waitForAvailable: waitForAvailable
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,6 +11,14 @@ const delay = function(ms) {
   return new Promise(resolve => setTimeout(() => resolve(), ms));
 };
 
+function cleanupSocket(socket) {
+  socket.removeAllListeners('connect');
+  socket.removeAllListeners('error');
+  socket.end();
+  socket.destroy();
+  socket.unref();
+}
+
 /**
  * Checks if a provided address is actively listening for incoming connections
  *
@@ -18,23 +26,16 @@ const delay = function(ms) {
  * @param {number} port the port to check for availability
  * @param {function} callback
  */
-const checkAvailable = (host, port, callback) => {
+function checkAvailable(host, port, callback) {
   const socket = new net.Socket();
-  function cleanup() {
-    socket.removeAllListeners('connect');
-    socket.removeAllListeners('error');
-    socket.end();
-    socket.destroy();
-    socket.unref();
-  }
 
   socket.on('connect', () => {
-    cleanup();
+    cleanupSocket(socket);
     callback(null, true);
   });
 
   socket.on('error', err => {
-    cleanup();
+    cleanupSocket(socket);
     if (err.code !== 'ECONNREFUSED') {
       return callback(err);
     }
@@ -56,7 +57,7 @@ const checkAvailable = (host, port, callback) => {
  * @param {number} [options.retryCount] the number of times to attempt retry
  * @param {function} callback
  */
-const waitForAvailable = (host, port, options, callback) => {
+function waitForAvailable(host, port, options, callback) {
   if (typeof options === 'function') (callback = options), (options = {});
   options = Object.assign(
     {},


### PR DESCRIPTION
Previously we only tested whether a particular log message showed
up to indicate when a server was ready to connect to. It turns out
this is somewhat flakey, so I've added an additional check to see
if the host is actively listening for connections on the provided
port number.