### PR TITLE
fix(replset): fix set protocolVersion=1 for replicaset configuration in MongoDB 3.2+

### DIFF
--- a/lib/replset.js
+++ b/lib/replset.js
@@ -25,11 +25,11 @@ class ReplSet extends EventEmitter {
    * @param {number} [nodes[].votes] Number of votes this member will cast in a replicaset election
    * @param {object} [nodes[].options] Options for the member server process (see {@link Server})
    * @param {object} [options] Any options for the replicaset
-   * @param {object} [options.configSettings] Any options for the replicaset
-   * @param {object} [options.protocolVersion] Any options for the replicaset
-   * @param {object} [options.replSet] Any options for the replicaset
-   * @param {object} [options.electionCycleWaitMS] Any options for the replicaset
-   * @param {object} [options.retryWaitMS] Any options for the replicaset
+   * @param {object} [options.configSettings] Configuration settings that apply to the whole replicaset. See {@link https://docs.mongodb.com/manual/reference/replica-configuration/#settings} for more info.
+   * @param {number} [options.protocolVersion] Protocol version for replicaset, can be 0 or 1. Version 1 is supported from MongoDB 3.2+ and required for MongoDB 4.0+.
+   * @param {string} options.replSet Name of the replicaset
+   * @param {number} [options.electionCycleWaitMS=31000] Amount of time to wait for an election cycle to take place in ms
+   * @param {number} [options.retryWaitMS=5000] Amount of time to wait before rechecking for a new primary after the election cycle wait time has passed in ms
    */
   constructor(binary, nodes, options) {
     super();

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -156,7 +156,14 @@ class ReplSet extends EventEmitter {
         });
 
         // Get the version information
+        // Use the given protocol version or the minimum required.
+        // MongoDB 4.0+ requires version 1, version supported since 3.2
         var result = yield self.discover();
+        var protocolVersion =
+          self.options.protocolVersion ||
+          (result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2))
+            ? 1
+            : 0;
 
         // Boot all the servers
         for (var i = 0; i < self.managers.length; i++) {
@@ -167,6 +174,7 @@ class ReplSet extends EventEmitter {
         var config = generateConfiguration(
           self.replSet,
           self.version,
+          protocolVersion,
           self.nodes,
           self.configSettings
         );
@@ -1161,7 +1169,7 @@ class ReplSet extends EventEmitter {
 /*
  * Generate the replicaset configuration file
  */
-var generateConfiguration = function(_id, version, nodes, settings) {
+var generateConfiguration = function(_id, version, protocolVersion, nodes, settings) {
   var members = [];
 
   // Generate members
@@ -1189,6 +1197,7 @@ var generateConfiguration = function(_id, version, nodes, settings) {
   var configuration = {
     _id: _id,
     version: version,
+    protocolVersion: protocolVersion,
     members: members
   };
 

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -185,11 +185,11 @@ class ReplSet extends EventEmitter {
         // Set protocol version for replicaset to be given value in options or
         // default to version 1 if using MongoDB 3.2 or above
         // Protocol version 1 is supported since 3.2+ and required for 4.0+
-        var protocolVersion =
-          self.protocolVersion ||
-          (result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2))
-            ? 1
-            : 0;
+        var protocolVersion = self.protocolVersion;
+        if (typeof protocolVersion !== 'number') {
+          protocolVersion =
+            result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2) ? 1 : 0;
+        }
 
         // Boot all the servers
         for (var i = 0; i < self.managers.length; i++) {

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -193,8 +193,8 @@ class ReplSet extends EventEmitter {
           typeof self.options.protocolVersion === 'number'
             ? self.options.protocolVersion
             : result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2)
-              ? 1
-              : 0,
+            ? 1
+            : 0,
           self.nodes,
           self.configSettings
         );

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -11,6 +11,26 @@ const Promise = require('bluebird'),
   delay = require('./utils').delay;
 
 class ReplSet extends EventEmitter {
+  /**
+   * Create a replicaset server instance
+   *
+   * @param {string} [binary=mongod] Path to MongoDB server daemon binary
+   * @param {object[]} [nodes] Members in the replicaset
+   * @param {boolean} [nodes[].arbiter] Sets member to be an arbiter
+   * @param {boolean} [nodes[].builIndexes] Specifies whether indices will be built on this member
+   * @param {boolean} [nodes[].hidden] Hides the member from replicaset
+   * @param {number} [nodes[].priority] Number that indicates relative eligibility for a member to become a primary
+   * @param {object} [nodes[].tags] Tag set containing arbitrary keys and values in order to give read/write preference to particular members
+   * @param {number} [nodes[].slaveDelay] Number of seconds behind primary member that this member should lag
+   * @param {number} [nodes[].votes] Number of votes this member will cast in a replicaset election
+   * @param {object} [nodes[].options] Options for the member server process (see {@link Server})
+   * @param {object} [options] Any options for the replicaset
+   * @param {object} [options.configSettings] Any options for the replicaset
+   * @param {object} [options.protocolVersion] Any options for the replicaset
+   * @param {object} [options.replSet] Any options for the replicaset
+   * @param {object} [options.electionCycleWaitMS] Any options for the replicaset
+   * @param {object} [options.retryWaitMS] Any options for the replicaset
+   */
   constructor(binary, nodes, options) {
     super();
     options = options || {};
@@ -60,7 +80,11 @@ class ReplSet extends EventEmitter {
 
     // Basic config settings for replicaset
     this.version = 1;
+    this.protocolVersion = options.protocolVersion;
     this.replSet = options.replSet;
+
+    // Remove the values from the options
+    delete this.options['protocolVersion'];
 
     // Contains all the configurations
     this.configurations = [];
@@ -156,11 +180,13 @@ class ReplSet extends EventEmitter {
         });
 
         // Get the version information
-        // Use the given protocol version or the minimum required.
-        // MongoDB 4.0+ requires version 1, version supported since 3.2
         var result = yield self.discover();
+
+        // Set protocol version for replicaset to be given value in options or
+        // default to version 1 if using MongoDB 3.2 or above
+        // Protocol version 1 is supported since 3.2+ and required for 4.0+
         var protocolVersion =
-          self.options.protocolVersion ||
+          self.protocolVersion ||
           (result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2))
             ? 1
             : 0;

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -178,23 +178,25 @@ class ReplSet extends EventEmitter {
         // Get the version information
         var result = yield self.discover();
 
+        // Set protocol version for replicaset to be given value in options or
+        // default to version 1 if using MongoDB 3.2 or above
+        // Protocol version 1 is supported since 3.2+ and required for 4.0+
+        let protocolVersion = self.options.protocolVersion;
+        if (typeof protocolVersion !== 'number') {
+          protocolVersion =
+            result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2) ? 1 : 0;
+        }
+
         // Boot all the servers
         for (var i = 0; i < self.managers.length; i++) {
           yield self.managers[i].start();
         }
 
         // Time to configure the servers by generating the
-        // Set protocol version for replicaset to be given value in options or
-        // default to version 1 if using MongoDB 3.2 or above
-        // Protocol version 1 is supported since 3.2+ and required for 4.0+
         var config = generateConfiguration(
           self.replSet,
           self.version,
-          typeof self.options.protocolVersion === 'number'
-            ? self.options.protocolVersion
-            : result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2)
-            ? 1
-            : 0,
+          protocolVersion,
           self.nodes,
           self.configSettings
         );

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -80,11 +80,7 @@ class ReplSet extends EventEmitter {
 
     // Basic config settings for replicaset
     this.version = 1;
-    this.protocolVersion = options.protocolVersion;
     this.replSet = options.replSet;
-
-    // Remove the values from the options
-    delete this.options['protocolVersion'];
 
     // Contains all the configurations
     this.configurations = [];
@@ -182,25 +178,23 @@ class ReplSet extends EventEmitter {
         // Get the version information
         var result = yield self.discover();
 
-        // Set protocol version for replicaset to be given value in options or
-        // default to version 1 if using MongoDB 3.2 or above
-        // Protocol version 1 is supported since 3.2+ and required for 4.0+
-        var protocolVersion = self.protocolVersion;
-        if (typeof protocolVersion !== 'number') {
-          protocolVersion =
-            result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2) ? 1 : 0;
-        }
-
         // Boot all the servers
         for (var i = 0; i < self.managers.length; i++) {
           yield self.managers[i].start();
         }
 
         // Time to configure the servers by generating the
+        // Set protocol version for replicaset to be given value in options or
+        // default to version 1 if using MongoDB 3.2 or above
+        // Protocol version 1 is supported since 3.2+ and required for 4.0+
         var config = generateConfiguration(
           self.replSet,
           self.version,
-          protocolVersion,
+          typeof self.options.protocolVersion === 'number'
+            ? self.options.protocolVersion
+            : result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2)
+              ? 1
+              : 0,
           self.nodes,
           self.configSettings
         );

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,12 +13,6 @@ const Promise = require('bluebird'),
   waitForAvailable = require('./utils').waitForAvailable;
 
 class Server extends EventEmitter {
-  /**
-   * Test
-   * @param {*} binary
-   * @param {*} options
-   * @param {*} clientOptions
-   */
   constructor(binary, options, clientOptions) {
     super();
     options = options || {};

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,6 +13,12 @@ const Promise = require('bluebird'),
   waitForAvailable = require('./utils').waitForAvailable;
 
 class Server extends EventEmitter {
+  /**
+   * Test
+   * @param {*} binary
+   * @param {*} options
+   * @param {*} clientOptions
+   */
   constructor(binary, options, clientOptions) {
     super();
     options = options || {};


### PR DESCRIPTION
Replicaset configuration has two protocol versions. *protocolVersion* 0 is the original. *protocolVersion* 1 was added in MongoDB 3.2 and is **required** in MongoDB 4.0+ [source](https://docs.mongodb.com/manual/reference/replica-set-protocol-versions/).

*protocolVersion* field is missing in this library. This PR adds the *protocolVersion* and allows the user to manually specify it. The default is to set the protocolVersion to 1 if using MongoDB 3.2+, otherwise set to 0.

This is the error message that appears if you try to run this library with MongoDB 4.0+:
```
MongoError: Support for replication protocol version 0 was removed in MongoDB 4.0. Downgrade to MongoDB version 3.6 and upgrade your protocol version to 1 before upgrading your MongoDB version
```

**Note:** When running the tests, I received some error if the protocolVersion was not set to 1 for MongoDB 3.2+. I don't remember exactly but it had to do with the Shard configuration servers.