### PR TITLE
chore(*): fix formatting issues & bump package versions

### DIFF
--- a/lib/mongos.js
+++ b/lib/mongos.js
@@ -303,7 +303,9 @@ class Mongos extends EventEmitter {
             options: self.options
           });
 
-          self.logger.error(f('failed to start mongos instance [%s]', commandLine));
+          self.logger.error(
+            f('failed to start mongos instance [%s]\n%j\n%s', commandLine, err, stdout)
+          );
 
           reject(new Error({ error: err, stdout: stdout, stderr: stderr }));
         });
@@ -311,8 +313,10 @@ class Mongos extends EventEmitter {
         // Process terminated
         self.process.on('close', function(code) {
           if ((self.state === 'stopped' && stdout === '') || code !== 0) {
-            self.logger.error(f('failed to start mongos instance [%s]', commandLine));
-            return reject(new Error(f('failed to start mongos with options %s', commandOptions)));
+            self.logger.error(f('failed to start mongos instance [%s]\n%s', commandLine, stdout));
+            return reject(
+              new Error(f('failed to start mongos with options %s\n%s', commandOptions, stdout))
+            );
           }
 
           self.state = 'stopped';
@@ -410,6 +414,9 @@ class Mongos extends EventEmitter {
       if (!self.process) return resolve();
 
       // Wait for service to stop
+      // Remove error and close listeners because they are still attached from when the process was started
+      self.process.removeAllListeners('error');
+      self.process.removeAllListeners('close');
       self.process.once('error', reject);
       self.process.on('close', function() {
         if (self.logger.isInfo()) {

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -235,7 +235,7 @@ class ReplSet extends EventEmitter {
 
         // Now monitor until we have all the servers in a healthy state
         while (true) {
-          // Wait for 200 ms before trying again
+          // Wait for 1000 ms before trying again
           yield delay(1000);
           // console.log("================= start 6:1")
 
@@ -291,8 +291,10 @@ class ReplSet extends EventEmitter {
 
         // Wait for the primary to appear in ismaster result
         yield self.waitForPrimary();
+
         // Get the last seen election Id
         var ismaster = yield self.managers[0].ismaster();
+
         // Save the current election Id if it exists
         self.electionId = ismaster.electionId;
         self.lastKnownPrimary = ismaster.me;

--- a/lib/server.js
+++ b/lib/server.js
@@ -402,12 +402,20 @@ class Server extends EventEmitter {
             stedrr: stderr.toString(),
             options: self.options
           });
+
+          self.logger.error(
+            f('failed to start mongod instance [%s]\n%j\n%s', commandLine, err, stdout)
+          );
+
           reject(new Error({ error: err, stdout: stdout, stderr: stderr }));
         });
 
         // Process terminated
         self.process.on('close', function(code) {
           if ((self.state === 'stopped' && stdout === '') || code !== 0) {
+            self.logger.error(
+              f('failed to start mongod instance [%s]\n%s', commandOptions, stdout)
+            );
             return reject(
               new Error(f('failed to start mongod with options %s\n%s', commandOptions, stdout))
             );
@@ -512,6 +520,9 @@ class Server extends EventEmitter {
       }
 
       // Wait for service to stop
+      // Remove error and close listeners because they are still attached from when the process was started
+      self.process.removeAllListeners('error');
+      self.process.removeAllListeners('close');
       self.process.once('error', reject);
       self.process.on('close', function() {
         // Set process to stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -183,13 +183,13 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
     },
     "bl": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
         "readable-stream": "2.3.6",
@@ -197,9 +197,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -211,9 +211,9 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "bson": {
@@ -342,9 +342,9 @@
       "dev": true
     },
     "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "circular-json": {
       "version": "0.3.3",
@@ -414,9 +414,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.15.1",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "compare-func": {
@@ -832,9 +832,9 @@
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "doctrine": {
@@ -952,12 +952,12 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz",
-      "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz",
+      "integrity": "sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==",
       "dev": true,
       "requires": {
-        "fast-diff": "1.1.2",
+        "fast-diff": "1.2.0",
         "jest-docblock": "21.2.0"
       }
     },
@@ -1039,9 +1039,9 @@
       }
     },
     "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
     "external-editor": {
       "version": "2.2.0",
@@ -1061,9 +1061,9 @@
       "dev": true
     },
     "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1352,9 +1352,9 @@
       "dev": true
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "handlebars": {
@@ -1685,13 +1685,13 @@
       "dev": true
     },
     "kerberos": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-1.0.0.tgz",
-      "integrity": "sha512-iYA/5PICH3BD18kgkjH/UjLroxTilNqrEuADFNzPqbwiJn79E+lP0U8LfHqqMGqW0qSi4YaMhwLWowKh0dSn4A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-1.1.2.tgz",
+      "integrity": "sha512-N+CeRTi0f6ov85Fx+w/epVPTBy6bovoWjUCD6pvXoHWBWeqI6+ViV2psdoSc4CRtiZfJkhvYO3b47I4hJfOu7Q==",
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.11.0",
-        "prebuild-install": "5.0.0"
+        "bindings": "1.3.1",
+        "nan": "2.12.1",
+        "prebuild-install": "5.2.2"
       }
     },
     "kind-of": {
@@ -1831,6 +1831,12 @@
         "mimic-fn": "1.2.0"
       }
     },
+    "memory-pager": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.3.1.tgz",
+      "integrity": "sha512-pUf/sGkym2WqFZYTVmdASnSbNfpGc9rwxEHOePx4lT/fD+NHGL1U16Uy4o6PMiVcDv4mp6MI/vaF0c/Kd1QEUQ==",
+      "optional": true
+    },
     "meow": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
@@ -1921,36 +1927,31 @@
       }
     },
     "mocha": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
-      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
         "debug": "3.1.0",
-        "diff": "3.3.1",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
-        "growl": "1.10.3",
+        "growl": "1.10.5",
         "he": "1.1.1",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "supports-color": "5.4.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -1962,13 +1963,14 @@
       "dev": true
     },
     "mongodb-core": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.2.tgz",
-      "integrity": "sha512-R2XxGzsmhlUeOK2jKATj1TWn3q3qNcJpKrSh0rhaBSHxJmV7WZ+ikjocdY8VdJxUkKqOxM8rxMqOAEzeJ3p1ww==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.9.tgz",
+      "integrity": "sha512-MJpciDABXMchrZphh3vMcqu8hkNf/Mi+Gk6btOimVg1XMxLXh87j6FAvRm+KmwD1A9fpu3qRQYcbQe4egj23og==",
       "requires": {
         "bson": "1.1.0",
         "require_optional": "1.0.1",
-        "saslprep": "1.0.1"
+        "safe-buffer": "5.1.2",
+        "saslprep": "1.0.2"
       }
     },
     "ms": {
@@ -1984,9 +1986,14 @@
       "dev": true
     },
     "nan": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-      "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+    },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -1995,9 +2002,9 @@
       "dev": true
     },
     "node-abi": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-      "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.0.tgz",
+      "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
       "requires": {
         "semver": "5.5.1"
       }
@@ -2112,7 +2119,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
@@ -2246,16 +2253,17 @@
       "dev": true
     },
     "prebuild-install": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.0.0.tgz",
-      "integrity": "sha512-AvcPLFqNz/hDd6o7qLj8i9xB479P9jSjA/p6m4927CRfY3tsmPfyFmD7RKXtdp6I2d1BAIVBgJoj5mxRJDZL4w==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.2.tgz",
+      "integrity": "sha512-4e8VJnP3zJdZv/uP0eNWmr2r9urp4NECw7Mt1OSAi3rcLrbBRxGiAkfUFtre2MhQ5wfREAjRV+K1gubvs/GPsA==",
       "requires": {
         "detect-libc": "1.0.3",
-        "expand-template": "1.1.1",
+        "expand-template": "2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "node-abi": "2.4.3",
+        "napi-build-utils": "1.0.1",
+        "node-abi": "2.5.0",
         "noop-logger": "0.1.1",
         "npmlog": "4.1.2",
         "os-homedir": "1.0.2",
@@ -2274,9 +2282,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
-      "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
       "dev": true
     },
     "process-nextick-args": {
@@ -2567,10 +2575,13 @@
       "dev": true
     },
     "saslprep": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.1.tgz",
-      "integrity": "sha512-ntN6SbE3hRqd45PKKadRPgA+xHPWg5lPSj2JWJdJvjTwXDDfkPVtXWvP8jJojvnm+rAsZ2b299C5NwZqq818EA==",
-      "optional": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.2.tgz",
+      "integrity": "sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "3.0.3"
+      }
     },
     "semver": {
       "version": "5.5.1",
@@ -2641,6 +2652,15 @@
       "dev": true,
       "requires": {
         "amdefine": "1.0.1"
+      }
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "1.3.1"
       }
     },
     "spdx-correct": {
@@ -2847,10 +2867,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
-        "chownr": "1.0.1",
+        "chownr": "1.1.1",
         "mkdirp": "0.5.1",
         "pump": "1.0.3",
-        "tar-stream": "1.6.1"
+        "tar-stream": "1.6.2"
       },
       "dependencies": {
         "pump": {
@@ -2865,9 +2885,9 @@
       }
     },
     "tar-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "requires": {
         "bl": "1.2.2",
         "buffer-alloc": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
   },
   "homepage": "https://github.com/christkv/mongodb-topology-manager",
   "dependencies": {
-    "bluebird": "^3.5.1",
+    "bluebird": "^3.5.3",
     "co": "^4.6.0",
-    "kerberos": "^1.0.0",
+    "kerberos": "^1.1.2",
     "mkdirp": "^0.5.1",
-    "mongodb-core": "^3.1.2",
+    "mongodb-core": "^3.1.9",
     "rimraf": "^2.6.2"
   },
   "devDependencies": {
-    "eslint": "^4.13.1",
-    "eslint-plugin-prettier": "^2.4.0",
-    "mocha": "^4.0.1",
-    "prettier": "^1.9.2",
+    "eslint": "^5.10.0",
+    "eslint-plugin-prettier": "^3.0.0",
+    "mocha": "^5.2.0",
+    "prettier": "^1.15.3",
     "standard-version": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "rimraf": "^2.6.2"
   },
   "devDependencies": {
-    "eslint": "^5.10.0",
+    "eslint": "^4.19.1",
     "eslint-plugin-prettier": "^3.0.0",
     "mocha": "^5.2.0",
     "prettier": "^1.15.3",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "eslint": "^4.19.1",
-    "eslint-plugin-prettier": "^3.0.0",
+    "eslint-plugin-prettier": "^2.7.0",
     "mocha": "^5.2.0",
     "prettier": "^1.15.3",
     "standard-version": "^4.4.0"

--- a/test/replset_tests.js
+++ b/test/replset_tests.js
@@ -644,7 +644,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -652,7 +652,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -662,7 +662,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }
@@ -687,12 +687,12 @@ describe('ReplSet', function() {
         var arbiters = yield topology.arbiters();
 
         // Verify primary
-        assert.strictEqual(primary.host, 'localhost');
+        assert.strictEqual(primary.host, '127.0.0.1');
         assert.ok(primary.port === 31000 || primary.port === 31001);
 
         // Verify secondaries
         assert.strictEqual(secondaries.length, 1);
-        assert.strictEqual(secondaries[0].host, 'localhost');
+        assert.strictEqual(secondaries[0].host, '127.0.0.1');
         assert.strictEqual(secondaries[0].port, primary.port === 31000 ? 31001 : 31000);
 
         // Verify passives
@@ -700,7 +700,7 @@ describe('ReplSet', function() {
 
         // Verify arbiters
         assert.strictEqual(arbiters.length, 1);
-        assert.strictEqual(arbiters[0].host, 'localhost');
+        assert.strictEqual(arbiters[0].host, '127.0.0.1');
         assert.strictEqual(arbiters[0].port, 31002);
 
         // Stop the set

--- a/test/replset_tests.js
+++ b/test/replset_tests.js
@@ -325,8 +325,8 @@ describe('ReplSet', function() {
         // Assert we have the expected number of instances
         var primary = yield topology.primary();
         var ismaster = yield primary.ismaster();
-        assert.equal(1, ismaster.arbiters.length);
-        assert.equal(3, ismaster.hosts.length);
+        assert.strictEqual(1, ismaster.arbiters.length);
+        assert.strictEqual(3, ismaster.hosts.length);
 
         // Stop the set
         yield topology.stop();
@@ -404,8 +404,8 @@ describe('ReplSet', function() {
         // Assert we have the expected number of instances
         var primary = yield topology.primary();
         var ismaster = yield primary.ismaster();
-        assert.equal(1, ismaster.arbiters.length);
-        assert.equal(3, ismaster.hosts.length);
+        assert.strictEqual(1, ismaster.arbiters.length);
+        assert.strictEqual(3, ismaster.hosts.length);
 
         // Stop the set
         yield topology.stop();
@@ -481,8 +481,8 @@ describe('ReplSet', function() {
         // Assert we have the expected number of instances
         var primary = yield topology.primary();
         var ismaster = yield primary.ismaster();
-        assert.equal(1, ismaster.arbiters.length);
-        assert.equal(2, ismaster.hosts.length);
+        assert.strictEqual(1, ismaster.arbiters.length);
+        assert.strictEqual(2, ismaster.hosts.length);
 
         // Stop the set
         yield topology.stop();
@@ -548,8 +548,8 @@ describe('ReplSet', function() {
 
         // Assert we have the expected number of instances
         var ismaster = yield secondaries[0].ismaster();
-        assert.equal(false, ismaster.secondary);
-        assert.equal(false, ismaster.ismaster);
+        assert.strictEqual(false, ismaster.secondary);
+        assert.strictEqual(false, ismaster.ismaster);
 
         // Wait for server to come back
         yield topology.maintenance(false, secondaries[0], {
@@ -557,7 +557,7 @@ describe('ReplSet', function() {
         });
 
         ismaster = yield secondaries[0].ismaster();
-        assert.equal(true, ismaster.secondary);
+        assert.strictEqual(true, ismaster.secondary);
 
         // Stop the set
         yield topology.stop();
@@ -624,7 +624,7 @@ describe('ReplSet', function() {
         // Get the current configuration
         var primary = yield topology.primary();
         var currentConfig = yield topology.configuration(primary);
-        assert.equal(10, currentConfig.members[2].priority);
+        assert.strictEqual(10, currentConfig.members[2].priority);
 
         // Stop the set
         yield topology.stop();

--- a/test/replset_tests.js
+++ b/test/replset_tests.js
@@ -17,7 +17,6 @@ describe('ReplSet', function() {
 
   describe('manager', function() {
     it('establish server version', function() {
-
       return co(function*() {
         var ReplSet = require('../').ReplSet;
 

--- a/test/replset_tests.js
+++ b/test/replset_tests.js
@@ -6,6 +6,8 @@ var co = require('co'),
   Promise = require('bluebird');
 
 describe('ReplSet', function() {
+  this.timeout(1000000);
+
   // Context variable stores all managers to clean up after test is completed
   var managers = [];
 
@@ -15,7 +17,6 @@ describe('ReplSet', function() {
 
   describe('manager', function() {
     it('establish server version', function() {
-      this.timeout(1000000);
 
       return co(function*() {
         var ReplSet = require('../').ReplSet;
@@ -27,7 +28,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -35,7 +36,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -45,7 +46,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }
@@ -59,6 +60,7 @@ describe('ReplSet', function() {
 
         // Perform discovery
         var version = yield topology.discover();
+
         // Expect 3 integers
         assert.ok(typeof version.version[0] === 'number');
         assert.ok(typeof version.version[1] === 'number');
@@ -67,8 +69,6 @@ describe('ReplSet', function() {
     });
 
     it('start simple replicaset with 1 primary, 1 secondary and one arbiter', function() {
-      this.timeout(1000000);
-
       return co(function*() {
         var ReplSet = require('../').ReplSet;
 
@@ -79,7 +79,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -87,7 +87,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -97,7 +97,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }
@@ -121,8 +121,6 @@ describe('ReplSet', function() {
     });
 
     it('start simple ssl replicaset with 1 primary, 1 secondary and one arbiter', function() {
-      this.timeout(200000);
-
       return co(function*() {
         var ReplSet = require('../').ReplSet;
 
@@ -133,7 +131,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname),
 
@@ -146,7 +144,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname),
 
@@ -161,7 +159,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname),
 
@@ -198,8 +196,6 @@ describe('ReplSet', function() {
     });
 
     it('stepdown primary', function() {
-      this.timeout(200000);
-
       return co(function*() {
         var ReplSet = require('../').ReplSet;
 
@@ -210,7 +206,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -218,7 +214,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -228,7 +224,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }
@@ -263,8 +259,6 @@ describe('ReplSet', function() {
     });
 
     it('add new member to set', function() {
-      this.timeout(200000);
-
       return co(function*() {
         var ReplSet = require('../').ReplSet;
 
@@ -275,7 +269,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -283,7 +277,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -293,7 +287,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }
@@ -317,7 +311,7 @@ describe('ReplSet', function() {
         yield topology.addMember(
           {
             options: {
-              bind_ip: 'localhost',
+              bind_ip: '127.0.0.1',
               port: 31003,
               dbpath: f('%s/../db/31003', __dirname)
             }
@@ -340,8 +334,6 @@ describe('ReplSet', function() {
     });
 
     it('add new member to set with high priority', function() {
-      this.timeout(200000);
-
       // // Set the info level
       // Logger.setLevel('info');
 
@@ -355,7 +347,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -363,7 +355,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -373,7 +365,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }
@@ -398,7 +390,7 @@ describe('ReplSet', function() {
           {
             priority: 20,
             options: {
-              bind_ip: 'localhost',
+              bind_ip: '127.0.0.1',
               port: 31003,
               dbpath: f('%s/../db/31003', __dirname)
             }
@@ -421,8 +413,6 @@ describe('ReplSet', function() {
     });
 
     it('remove member from set', function() {
-      this.timeout(200000);
-
       return co(function*() {
         var ReplSet = require('../').ReplSet;
 
@@ -433,7 +423,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -441,7 +431,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -451,7 +441,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }
@@ -459,7 +449,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31003,
                 dbpath: f('%s/../db/31003', __dirname)
               }
@@ -500,8 +490,6 @@ describe('ReplSet', function() {
     });
 
     it('put secondary in maintenance mode', function() {
-      this.timeout(200000);
-
       return co(function*() {
         var ReplSet = require('../').ReplSet;
 
@@ -512,7 +500,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -520,7 +508,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -530,7 +518,7 @@ describe('ReplSet', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }
@@ -577,8 +565,6 @@ describe('ReplSet', function() {
     });
 
     it('reconfigure using existing configuration', function() {
-      this.timeout(200000);
-
       return co(function*() {
         var ReplSet = require('../').ReplSet;
 
@@ -589,7 +575,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname)
               }
@@ -597,7 +583,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname)
               }
@@ -605,7 +591,7 @@ describe('ReplSet', function() {
             {
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname)
               }

--- a/test/sharded_tests.js
+++ b/test/sharded_tests.js
@@ -6,6 +6,8 @@ var co = require('co'),
   Promise = require('bluebird');
 
 describe('Sharded', function() {
+  this.timeout(250000);
+
   // Context variable stores all managers to clean up after test is completed
   var managers = [];
 
@@ -21,8 +23,10 @@ describe('Sharded', function() {
         var Sharded = require('../').Sharded;
         // Create new instance
         var topology = new Sharded('mongod');
+
         // Perform discovery
         var version = yield topology.discover();
+
         // Expect 3 integers
         assert.ok(typeof version.version[0] === 'number');
         assert.ok(typeof version.version[1] === 'number');
@@ -31,8 +35,6 @@ describe('Sharded', function() {
     });
 
     it('create a sharded system with 2 shards', function() {
-      this.timeout(250000);
-
       return co(function*() {
         var Sharded = require('../').Sharded;
         // Create new instance
@@ -47,7 +49,7 @@ describe('Sharded', function() {
           [
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname),
                 shardsvr: null
@@ -55,7 +57,7 @@ describe('Sharded', function() {
             },
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname),
                 shardsvr: null
@@ -66,7 +68,7 @@ describe('Sharded', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname),
                 shardsvr: null
@@ -83,7 +85,7 @@ describe('Sharded', function() {
           [
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31010,
                 dbpath: f('%s/../db/31010', __dirname),
                 shardsvr: null
@@ -91,7 +93,7 @@ describe('Sharded', function() {
             },
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31011,
                 dbpath: f('%s/../db/31011', __dirname),
                 shardsvr: null
@@ -102,7 +104,7 @@ describe('Sharded', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31012,
                 dbpath: f('%s/../db/31012', __dirname),
                 shardsvr: null
@@ -119,21 +121,21 @@ describe('Sharded', function() {
           [
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 35000,
                 dbpath: f('%s/../db/35000', __dirname)
               }
             },
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 35001,
                 dbpath: f('%s/../db/35001', __dirname)
               }
             },
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 35002,
                 dbpath: f('%s/../db/35002', __dirname)
               }
@@ -148,14 +150,14 @@ describe('Sharded', function() {
         yield topology.addProxies(
           [
             {
-              bind_ip: 'localhost',
+              bind_ip: '127.0.0.1',
               port: 51000,
-              configdb: 'localhost:35000,localhost:35001,localhost:35002'
+              configdb: '127.0.0.1:35000,127.0.0.1:35001,127.0.0.1:35002'
             },
             {
-              bind_ip: 'localhost',
+              bind_ip: '127.0.0.1',
               port: 51001,
-              configdb: 'localhost:35000,localhost:35001,localhost:35002'
+              configdb: '127.0.0.1:35000,127.0.0.1:35001,127.0.0.1:35002'
             }
           ],
           {
@@ -180,8 +182,6 @@ describe('Sharded', function() {
     });
 
     it('create a sharded system with a single shard and take down mongos and bring it back', function() {
-      this.timeout(250000);
-
       return co(function*() {
         var Sharded = require('../').Sharded;
         // Create new instance
@@ -196,7 +196,7 @@ describe('Sharded', function() {
           [
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31000,
                 dbpath: f('%s/../db/31000', __dirname),
                 shardsvr: null
@@ -204,7 +204,7 @@ describe('Sharded', function() {
             },
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31001,
                 dbpath: f('%s/../db/31001', __dirname),
                 shardsvr: null
@@ -215,7 +215,7 @@ describe('Sharded', function() {
               arbiter: true,
               // mongod process options
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 31002,
                 dbpath: f('%s/../db/31002', __dirname),
                 shardsvr: null
@@ -232,21 +232,21 @@ describe('Sharded', function() {
           [
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 35000,
                 dbpath: f('%s/../db/35000', __dirname)
               }
             },
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 35001,
                 dbpath: f('%s/../db/35001', __dirname)
               }
             },
             {
               options: {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 35002,
                 dbpath: f('%s/../db/35002', __dirname)
               }
@@ -261,14 +261,14 @@ describe('Sharded', function() {
         yield topology.addProxies(
           [
             {
-              bind_ip: 'localhost',
+              bind_ip: '127.0.0.1',
               port: 51000,
-              configdb: 'localhost:35000,localhost:35001,localhost:35002'
+              configdb: '127.0.0.1:35000,127.0.0.1:35001,127.0.0.1:35002'
             },
             {
-              bind_ip: 'localhost',
+              bind_ip: '127.0.0.1',
               port: 51001,
-              configdb: 'localhost:35000,localhost:35001,localhost:35002'
+              configdb: '127.0.0.1:35000,127.0.0.1:35001,127.0.0.1:35002'
             }
           ],
           {
@@ -302,8 +302,6 @@ describe('Sharded', function() {
     });
 
     it('properly tears down a sharded system', function() {
-      this.timeout(120000);
-
       const Sharded = require('../').Sharded;
       const topology = new Sharded({
         mongod: 'mongod',
@@ -317,7 +315,7 @@ describe('Sharded', function() {
             [
               {
                 options: {
-                  bind_ip: 'localhost',
+                  bind_ip: '127.0.0.1',
                   port: 31000,
                   dbpath: f('%s/../db/31000', __dirname),
                   shardsvr: null
@@ -325,7 +323,7 @@ describe('Sharded', function() {
               },
               {
                 options: {
-                  bind_ip: 'localhost',
+                  bind_ip: '127.0.0.1',
                   port: 31001,
                   dbpath: f('%s/../db/31001', __dirname),
                   shardsvr: null
@@ -336,7 +334,7 @@ describe('Sharded', function() {
                 arbiter: true,
                 // mongod process options
                 options: {
-                  bind_ip: 'localhost',
+                  bind_ip: '127.0.0.1',
                   port: 31002,
                   dbpath: f('%s/../db/31002', __dirname),
                   shardsvr: null
@@ -353,21 +351,21 @@ describe('Sharded', function() {
             [
               {
                 options: {
-                  bind_ip: 'localhost',
+                  bind_ip: '127.0.0.1',
                   port: 35000,
                   dbpath: f('%s/../db/35000', __dirname)
                 }
               },
               {
                 options: {
-                  bind_ip: 'localhost',
+                  bind_ip: '127.0.0.1',
                   port: 35001,
                   dbpath: f('%s/../db/35001', __dirname)
                 }
               },
               {
                 options: {
-                  bind_ip: 'localhost',
+                  bind_ip: '127.0.0.1',
                   port: 35002,
                   dbpath: f('%s/../db/35002', __dirname)
                 }
@@ -382,14 +380,14 @@ describe('Sharded', function() {
           topology.addProxies(
             [
               {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 51000,
-                configdb: 'localhost:35000,localhost:35001,localhost:35002'
+                configdb: '127.0.0.1:35000,127.0.0.1:35001,127.0.0.1:35002'
               },
               {
-                bind_ip: 'localhost',
+                bind_ip: '127.0.0.1',
                 port: 51001,
-                configdb: 'localhost:35000,localhost:35001,localhost:35002'
+                configdb: '127.0.0.1:35000,127.0.0.1:35001,127.0.0.1:35002'
               }
             ],
             {

--- a/test/sharded_tests.js
+++ b/test/sharded_tests.js
@@ -400,7 +400,7 @@ describe('Sharded', function() {
         .then(() => topology.enableSharding('test'))
         .then(() => topology.shardCollection('test', 'testcollection', { _id: 1 }))
         .then(() => topology.stop())
-        .then(() => assert.equal(topology.state, 'stopped'));
+        .then(() => assert.strictEqual(topology.state, 'stopped'));
     });
   });
 });

--- a/test/single_server_tests.js
+++ b/test/single_server_tests.js
@@ -6,6 +6,8 @@ var co = require('co'),
   Promise = require('bluebird');
 
 describe('Server', function() {
+  this.timeout(50000);
+
   // Context variable stores all managers to clean up after test is completed
   var managers = [];
 
@@ -15,8 +17,6 @@ describe('Server', function() {
 
   describe('manager', function() {
     it('establish server version', function() {
-      this.timeout(50000);
-
       return co(function*() {
         var Server = require('../').Server;
         // Create new instance
@@ -31,8 +31,6 @@ describe('Server', function() {
     });
 
     it('start server instance', function() {
-      this.timeout(50000);
-
       return co(function*() {
         var Server = require('../').Server;
 
@@ -57,8 +55,6 @@ describe('Server', function() {
     });
 
     it('restart server instance', function() {
-      this.timeout(50000);
-
       return co(function*() {
         var Server = require('../').Server;
 
@@ -92,8 +88,6 @@ describe('Server', function() {
     });
 
     it('call ismaster on server instance', function() {
-      this.timeout(50000);
-
       return co(function*() {
         var Server = require('../').Server;
 
@@ -119,8 +113,6 @@ describe('Server', function() {
     });
 
     it('start up authenticated server', function() {
-      this.timeout(50000);
-
       return co(function*() {
         var Server = require('../').Server;
 
@@ -147,8 +139,6 @@ describe('Server', function() {
     });
 
     it('start up ssl server server', function() {
-      this.timeout(50000);
-
       return co(function*() {
         var Server = require('../').Server;
 

--- a/test/single_server_tests.js
+++ b/test/single_server_tests.js
@@ -105,7 +105,7 @@ describe('Server', function() {
 
         // Call ismaster
         var ismaster = yield server.ismaster();
-        assert.equal(true, ismaster.ismaster);
+        assert.strictEqual(true, ismaster.ismaster);
 
         // Stop the process
         yield server.stop();
@@ -131,7 +131,7 @@ describe('Server', function() {
 
         // Call ismaster
         var ismaster = yield server.ismaster();
-        assert.equal(true, ismaster.ismaster);
+        assert.strictEqual(true, ismaster.ismaster);
 
         // Stop the process
         yield server.stop();
@@ -171,7 +171,7 @@ describe('Server', function() {
 
         // Call ismaster
         var ismaster = yield server.ismaster();
-        assert.equal(true, ismaster.ismaster);
+        assert.strictEqual(true, ismaster.ismaster);
 
         // Stop the process
         yield server.stop();


### PR DESCRIPTION
Small formatting and less important changes were made in this PR and grouped together.

# Changes

* Bumped package versions to be up to date. 
* Add newlines to give more space and increase the readability of the code. This also follows the syntax of the library. 
* Fix a few mistakes in comments, spelling, grammar, etc.
* Switch to using assert.strictEqual from assert.equal because assert.equal is deprecated since v9.9.0
* Update one shard test to follow the *co* generator syntax
* Set timeout for entire test file rather than for each individual test. Less code and easier to change the timeout once than for each test itself when debugging.
* Include additional logging information when mongod/mongos server fails to start. The stdout data is printed out to aid in debugging issues.
* Change all test's `bind_ip` from **localhost** to **127.0.0.1**
    * Windows-specific error where local DNS resolver takes ~1s to resolve localhost to 127.0.0.1. When equivalent command was run on Linux, the DNS resolver would finish in tens of milliseconds. Not a big deal, but shaves off some running time for tests on Windows.