### PR TITLE
docs(README): fix ReplSet example options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ var topology = new ReplSet('mongod', [{
   }
 }, {
   // Type of node
-  arbiterOnly: true,
+  arbiter: true,
   // mongod process options
   options: {
     bind_ip: 'localhost', port: 31002, dbpath: './db-3'


### PR DESCRIPTION
Parameter to declare an arbiter is `arbiter` and not `arbiterOnly` in the options for ReplSet.