### PR TITLE
fix(prettier): fix prettier file paths for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run lint && mocha",
     "lint": "eslint index.js lib test",
-    "format": "prettier --print-width 100 --tab-width 2 --single-quote --write index.js 'test/**/*.js' 'lib/**/*.js'",
+    "format": "prettier --print-width 100 --tab-width 2 --single-quote --write index.js test/**/*.js lib/**/*.js",
     "release": "standard-version"
   },
   "repository": {


### PR DESCRIPTION
Running `npm run format` on Windows only formats `index.js` because the other two paths start with single quotes which is considered an invalid path. Remove single quotes to work on both Windows & Linux