### PR TITLE
fix(replset): fix PV for below MongoDB 3.2

### DIFF
--- a/lib/replset.js
+++ b/lib/replset.js
@@ -182,9 +182,11 @@ class ReplSet extends EventEmitter {
         // default to version 1 if using MongoDB 3.2 or above
         // Protocol version 1 is supported since 3.2+ and required for 4.0+
         let protocolVersion = self.options.protocolVersion;
-        if (typeof protocolVersion !== 'number') {
-          protocolVersion =
-            result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2) ? 1 : 0;
+        if (
+          typeof protocolVersion !== 'number' &&
+          (result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2))
+        ) {
+          protocolVersion = 1;
         }
 
         // Boot all the servers
@@ -1183,9 +1185,12 @@ var generateConfiguration = function(_id, version, protocolVersion, nodes, setti
   var configuration = {
     _id: _id,
     version: version,
-    protocolVersion: protocolVersion,
     members: members
   };
+
+  if (typeof protocolVersion === 'number') {
+    configuration.protocolVersion = protocolVersion;
+  }
 
   if (settings) {
     configuration.settings = settings;

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -26,7 +26,7 @@ class ReplSet extends EventEmitter {
    * @param {object} [nodes[].options] Options for the member server process (see {@link Server})
    * @param {object} [options] Any options for the replicaset
    * @param {object} [options.configSettings] Configuration settings that apply to the whole replicaset. See {@link https://docs.mongodb.com/manual/reference/replica-configuration/#settings} for more info.
-   * @param {number} [options.protocolVersion] Protocol version for replicaset, can be 0 or 1. Version 1 is supported from MongoDB 3.2+ and required for MongoDB 4.0+.
+   * @param {number} [options.protocolVersion] Protocol version for replicaset, can be 0 or 1. Field is supported from MongoDB 3.2+ and version 1 is required for MongoDB 4.0+.
    * @param {string} options.replSet Name of the replicaset
    * @param {number} [options.electionCycleWaitMS=31000] Amount of time to wait for an election cycle to take place in ms
    * @param {number} [options.retryWaitMS=5000] Amount of time to wait before rechecking for a new primary after the election cycle wait time has passed in ms

--- a/lib/replset.js
+++ b/lib/replset.js
@@ -181,12 +181,10 @@ class ReplSet extends EventEmitter {
         // Set protocol version for replicaset to be given value in options or
         // default to version 1 if using MongoDB 3.2 or above
         // Protocol version 1 is supported since 3.2+ and required for 4.0+
-        let protocolVersion = self.options.protocolVersion;
-        if (
-          typeof protocolVersion !== 'number' &&
-          (result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2))
-        ) {
-          protocolVersion = 1;
+        let protocolVersion;
+        if (result.version[0] >= 4 || (result.version[0] === 3 && result.version[1] >= 2)) {
+          protocolVersion =
+            typeof self.options.protocolVersion === 'number' ? self.options.protocolVersion : 1;
         }
 
         // Boot all the servers


### PR DESCRIPTION
Update logic for inclusion of `protocolVersion` in replicaset configuration. Only include the `protocolVersion` if using MongoDB 3.2 or above. This means that if the user specifies a `protocolVersion`, that will **only** be used if using MongoDB 3.2 and above.

When testing #21 with MongoDB versions below 3.2, errors occurred when configuring the replicaset configuration due to the inclusion of the `protocolVersion` field.

**Note:** I am not sure why the TravisCI tests succeeded for the **first** protocolVersion PR.