### PR TITLE
fix(replset): fix hanging in reconfigure randomly

### DIFF
--- a/lib/replset.js
+++ b/lib/replset.js
@@ -681,14 +681,14 @@ class ReplSet extends EventEmitter {
             if (
               ismaster.ismaster &&
               ismaster.electionId &&
-              !self.electionId.equals(ismaster.electionId)
+              !ismaster.electionId.equals(self.electionId)
             ) {
               yield self.waitForPrimary();
               return resolve();
             } else if (
               (ismaster.secondary || ismaster.arbiterOnly) &&
               ismaster.electionId &&
-              self.electionId.equals(ismaster.electionId)
+              ismaster.electionId.equals(self.electionId)
             ) {
               return resolve();
             } else if (


### PR DESCRIPTION
Fix issue where `reconfigure` function in `ReplSet` hangs forever due to `self.electionId` being undefined. Unsure of why `self.electionId` is null for servers but seems to randomly occur. 

Here is a screenshot showing the issue occurring while debugging. What occurs is that `self.electionId` is undefined and then calling `self.electionId.equals` causes an exception which is handled by simply delaying the retry amount. This in turn causes an infinite loop.
![Screenshot 1](https://i.imgur.com/Kc9qmCl.png)

Reconfigure replicaset test failed in #21 multiple times due to this issue: [https://travis-ci.org/mongodb-js/mongodb-topology-manager/jobs/472211457#L610](https://travis-ci.org/mongodb-js/mongodb-topology-manager/jobs/472211457#L610) & [https://travis-ci.org/mongodb-js/mongodb-topology-manager/jobs/471886303](https://travis-ci.org/mongodb-js/mongodb-topology-manager/jobs/471886303)